### PR TITLE
THRET-3: Enable Dependabot for NPM & Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "rossyman"
+    reviewers:
+      - "rossyman"
+    commit-message:
+      prefix: "THRET-D"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "rossyman"
+    reviewers:
+      - "rossyman"
+    commit-message:
+      prefix: "THRET-D"
+      include: "scope"


### PR DESCRIPTION
Setup Dependabot for GitHub Actions & NPM dependencies. Doing so will ensure bugs are dealt with quickly.

### Acceptance Criteria
- [x] Enable Dependabot for NPM
- [x] Enable Dependabot for GitHub Actions