### PR TITLE
THRET-8: Add Twitter Card

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -31,6 +31,11 @@
   <meta property="og:url" content="https://thretclothing.com/">
   <meta property="og:type" content="website">
 
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@thretclothing">
+  <meta name="twitter:title" content="Thret Clothing Co.">
+  <meta name="twitter:image" content="assets/images/open-graph/open-graph-1200x630.png">
+
 </head>
 <body>
   <thret-root></thret-root>


### PR DESCRIPTION
Add twitter specific SEO tags to ensure a summary image appears when embedded on Twitter.

### Acceptance Criteria
- [x] Twitter specific summary card image displayed
- [x] Twitter specific meta tag for Thret account