### PR TITLE
THRET-10: Remove relative locations to SEO images

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,21 +20,21 @@
   <link rel="icon" type="image/png" sizes="32x32" href="assets/images/icons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="assets/images/icons/favicon-16x16.png">
   <link rel="manifest" href="assets/site.webmanifest">
-  <link rel="mask-icon" href="/assets/images/icons/safari-pinned-tab.svg" color="#221f20">
-  <link rel="shortcut icon" href="/assets/images/icons/favicon.ico">
+  <link rel="mask-icon" href="assets/images/icons/safari-pinned-tab.svg" color="#221f20">
+  <link rel="shortcut icon" href="assets/images/icons/favicon.ico">
 
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:title" content="Thret Clothing Co.">
   <meta property="og:description" content="UK based skate and streetwear clothing brand on a mission to provide quality goods for an affordable price. 🛹 🏷">
-  <meta property="og:image" content="assets/images/open-graph/open-graph-1200x630.png">
+  <meta property="og:image" content="https://thretclothing.com/assets/images/open-graph/open-graph-1200x630.png">
   <meta property="og:url" content="https://thretclothing.com/">
   <meta property="og:type" content="website">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@thretclothing">
   <meta name="twitter:title" content="Thret Clothing Co.">
-  <meta name="twitter:image" content="assets/images/open-graph/open-graph-1200x630.png">
+  <meta name="twitter:image" content="https://thretclothing.com/assets/images/open-graph/open-graph-1200x630.png">
 
 </head>
 <body>


### PR DESCRIPTION
Some services like Twitter and Discord, cannot display relative images when being embedded. To solve this, images inside of `<meta>`  tags must be replaced with absolutely located ones.

### Acceptance Criteria
- [x] Relative paths to images in graph `<meta>` tags are replaced with absolute locations