### PR TITLE
THRET-12: Fix server build failing due to mismatched type

### DIFF
--- a/config/ts/tsconfig.server.json
+++ b/config/ts/tsconfig.server.json
@@ -10,7 +10,8 @@
   },
   "files": [
     "../../src/main.server.ts",
-    "../../server.ts"
+    "../../server.ts",
+    "../../src/types/twemoji.d.ts"
   ],
   "angularCompilerOptions": {
     "entryModule": "../../src/app/app.server.module#AppServerModule"


### PR DESCRIPTION
Mismatched type shows up when running `build:ssr`

### Acceptance Criteria
- [x] Fixes issue with types, when running `build:ssr`