### PR TITLE
THRET-R: Fix server build failing due to mismatched type

### DIFF
--- a/config/ts/tsconfig.server.json
+++ b/config/ts/tsconfig.server.json
@@ -10,7 +10,8 @@
   },
   "files": [
     "../../src/main.server.ts",
-    "../../server.ts"
+    "../../server.ts",
+    "../../src/types/twemoji.d.ts"
   ],
   "angularCompilerOptions": {
     "entryModule": "../../src/app/app.server.module#AppServerModule"


### PR DESCRIPTION
Fix server build failing due to mismatched type

### Changelog
- e4136c3b4d0bea6524b95761374c27d09cfe59d7 THRET-12: Fix server build failing due to mismatched type