### PR TITLE
THRET-22: Add Java 11 Support on Heroku

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
Currently the application breaks on Java 1.8, as Spring is expecting Java 11 to be available to it on Heroku.

### Acceptance Criteria
- [x] `system.properties` file declares `java.runtime.version=11`