### PR TITLE
THRET-R: Enable Java 11 on Heroku

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11

--- a/thret-clothing-web-ui/package.json
+++ b/thret-clothing-web-ui/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-jsdoc": "30.7.8",
     "eslint-plugin-prefer-arrow": "1.2.2",
     "@angular-eslint/builder": "0.8.0-beta.1",
-    "@angular-eslint/eslint-plugin": "0.8.0-beta.1",
+    "@angular-eslint/eslint-plugin": "0.8.0-beta.2",
     "@angular-eslint/eslint-plugin-template": "0.8.0-beta.1",
     "@angular-eslint/schematics": "^0.8.0-beta.1",
     "@angular-eslint/template-parser": "0.8.0-beta.1",


### PR DESCRIPTION
Enables Java 11 on Heroku and includes minor upgrade for ESLint.

### Changelog
- 53b56def7f5265635c8b314935d06110a0448fa6 THRET-22: Add Java 11 Support on Heroku (#45)
- 9cfd71c834a65ea84b6c63e3ff1f7504b7f5ae8a THRET-D(deps-dev): Bump @angular-eslint/eslint-plugin (#44)
