### PR TITLE
THRET-22: Pass server port as executable option

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -jar thret-clothing-web-app/target/thret-clothing-web-app.jar -Dserver.port=$PORT
+web: java $JAVA_OPTS -jar thret-clothing-web-app/target/thret-clothing-web-app.jar --server.port=$PORT


### PR DESCRIPTION
Passing the server port as a system property didn't seem to work, trying to pass as an executable option.

### Acceptance Criteria
- [x] Pass server port as executable option