### PR TITLE
THRET-23: Delegate routing to Angular when not matched by Spring

### DIFF
--- a/thret-clothing-web-app/pom.xml
+++ b/thret-clothing-web-app/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
@@ -9,43 +10,38 @@
   </parent>
 
   <packaging>jar</packaging>
-	<modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-	<artifactId>thret-clothing-web-app</artifactId>
+  <artifactId>thret-clothing-web-app</artifactId>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>repackage</id>
@@ -57,7 +53,7 @@
             </configuration>
           </execution>
         </executions>
-			</plugin>
-		</plugins>
-	</build>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/thret-clothing-web-app/src/main/java/clothing/thret/web/app/ThretClothingWebApplication.java
+++ b/thret-clothing-web-app/src/main/java/clothing/thret/web/app/ThretClothingWebApplication.java
@@ -4,9 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class ThretClothingWebAppApplication {
+public class ThretClothingWebApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ThretClothingWebAppApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(ThretClothingWebApplication.class, args);
+  }
 }

--- a/thret-clothing-web-app/src/main/java/clothing/thret/web/app/config/WebMvcConfiguration.java
+++ b/thret-clothing-web-app/src/main/java/clothing/thret/web/app/config/WebMvcConfiguration.java
@@ -1,0 +1,24 @@
+package clothing.thret.web.app.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfiguration implements WebMvcConfigurer {
+
+  @Override
+  public void addViewControllers(ViewControllerRegistry registry) {
+    registry
+      .addViewController("/{spring:\\w+}")
+      .setViewName("forward:/");
+
+    registry
+      .addViewController("/**/{spring:\\w+}")
+      .setViewName("forward:/");
+
+    registry
+      .addViewController("/{spring:\\w+}/**{spring:?!(\\.js|\\.css)$}")
+      .setViewName("forward:/");
+  }
+}

--- a/thret-clothing-web-app/src/test/java/clothing/thret/web/app/ThretClothingWebApplicationTests.java
+++ b/thret-clothing-web-app/src/test/java/clothing/thret/web/app/ThretClothingWebApplicationTests.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ThretClothingWebAppApplicationTests {
+class ThretClothingWebApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+  @Test
+  void contextLoads() {
+  }
 }


### PR DESCRIPTION
Delegate the responsibility of routing to Angular when a controller mapping is not found within the Spring Boot context.

### Acceptance Criteria
- [x] Routes not matched by Spring Boot will allow Angular routing to take control