### PR TITLE
THRET-24: Normalize spacing around footer elements on mobile

### DIFF
--- a/thret-clothing-web-ui/src/app/common/footer/components/footer.component.scss
+++ b/thret-clothing-web-ui/src/app/common/footer/components/footer.component.scss
@@ -20,8 +20,18 @@ footer {
     grid-template-rows: auto;
   }
 
-  & > div {
-    padding: 0 1rem;
+  @media (min-width: 1630px) {
+    & > div {
+      padding: 0 1rem;
+
+      &:first-of-type {
+        padding: 0 1rem 0 0;
+      }
+
+      &:last-of-type {
+        padding: 0 0 0 1rem;
+      }
+    }
   }
 
   & b {


### PR DESCRIPTION
Spacing around the footer elements is abnormally large on mobile devices and offsets the vertical content flow. We should nuke both the left and right padding / margin on foot elements where necessary to re-align the vertical flow.

### Acceptance Criteria
- [x] Normalized vertical flow
- [x] Fixed footer element alignment