### PR TITLE
THRET-R: Angular / Spring routing & footer fixes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -jar thret-clothing-web-app/target/thret-clothing-web-app.jar -Dserver.port=$PORT
+web: java $JAVA_OPTS -jar thret-clothing-web-app/target/thret-clothing-web-app.jar --server.port=$PORT

--- a/thret-clothing-web-app/pom.xml
+++ b/thret-clothing-web-app/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
@@ -9,43 +10,38 @@
   </parent>
 
   <packaging>jar</packaging>
-	<modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-	<artifactId>thret-clothing-web-app</artifactId>
+  <artifactId>thret-clothing-web-app</artifactId>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.junit.vintage</groupId>
-					<artifactId>junit-vintage-engine</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>io.projectreactor</groupId>
-			<artifactId>reactor-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>repackage</id>
@@ -57,7 +53,7 @@
             </configuration>
           </execution>
         </executions>
-			</plugin>
-		</plugins>
-	</build>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/thret-clothing-web-app/src/main/java/clothing/thret/web/app/ThretClothingWebApplication.java
+++ b/thret-clothing-web-app/src/main/java/clothing/thret/web/app/ThretClothingWebApplication.java
@@ -4,9 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class ThretClothingWebAppApplication {
+public class ThretClothingWebApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ThretClothingWebAppApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(ThretClothingWebApplication.class, args);
+  }
 }

--- a/thret-clothing-web-app/src/main/java/clothing/thret/web/app/config/WebMvcConfiguration.java
+++ b/thret-clothing-web-app/src/main/java/clothing/thret/web/app/config/WebMvcConfiguration.java
@@ -1,0 +1,24 @@
+package clothing.thret.web.app.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfiguration implements WebMvcConfigurer {
+
+  @Override
+  public void addViewControllers(ViewControllerRegistry registry) {
+    registry
+      .addViewController("/{spring:\\w+}")
+      .setViewName("forward:/");
+
+    registry
+      .addViewController("/**/{spring:\\w+}")
+      .setViewName("forward:/");
+
+    registry
+      .addViewController("/{spring:\\w+}/**{spring:?!(\\.js|\\.css)$}")
+      .setViewName("forward:/");
+  }
+}

--- a/thret-clothing-web-app/src/test/java/clothing/thret/web/app/ThretClothingWebApplicationTests.java
+++ b/thret-clothing-web-app/src/test/java/clothing/thret/web/app/ThretClothingWebApplicationTests.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ThretClothingWebAppApplicationTests {
+class ThretClothingWebApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+  @Test
+  void contextLoads() {
+  }
 }

--- a/thret-clothing-web-ui/package.json
+++ b/thret-clothing-web-ui/package.json
@@ -64,7 +64,7 @@
     "@angular-eslint/eslint-plugin": "0.8.0-beta.2",
     "@angular-eslint/eslint-plugin-template": "0.8.0-beta.1",
     "@angular-eslint/schematics": "^0.8.0-beta.1",
-    "@angular-eslint/template-parser": "0.8.0-beta.1",
+    "@angular-eslint/template-parser": "0.8.0-beta.2",
     "@typescript-eslint/eslint-plugin": "4.8.1",
     "@typescript-eslint/parser": "4.8.1"
   }

--- a/thret-clothing-web-ui/package.json
+++ b/thret-clothing-web-ui/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-prefer-arrow": "1.2.2",
     "@angular-eslint/builder": "0.8.0-beta.1",
     "@angular-eslint/eslint-plugin": "0.8.0-beta.2",
-    "@angular-eslint/eslint-plugin-template": "0.8.0-beta.1",
+    "@angular-eslint/eslint-plugin-template": "0.8.0-beta.2",
     "@angular-eslint/schematics": "^0.8.0-beta.1",
     "@angular-eslint/template-parser": "0.8.0-beta.2",
     "@typescript-eslint/eslint-plugin": "4.8.1",

--- a/thret-clothing-web-ui/src/app/common/footer/components/footer.component.scss
+++ b/thret-clothing-web-ui/src/app/common/footer/components/footer.component.scss
@@ -20,8 +20,18 @@ footer {
     grid-template-rows: auto;
   }
 
-  & > div {
-    padding: 0 1rem;
+  @media (min-width: 1630px) {
+    & > div {
+      padding: 0 1rem;
+
+      &:first-of-type {
+        padding: 0 1rem 0 0;
+      }
+
+      &:last-of-type {
+        padding: 0 0 0 1rem;
+      }
+    }
   }
 
   & b {


### PR DESCRIPTION
Fixes to enable routing delegation to Angular from Spring. Also includes footer fixes for vertical content flow

### Changelog
- 4b5b4739008be89810c5fbf00ae08b7b156427d5 THRET-24: Normalize spacing around footer elements on mobile (#52)
- ba9e8e9948b6d2b7fa694427d60022621a22c9fc THRET-23: Delegate routing to Angular when not matched by Spring (#51)
- 21f4ffb410ba6ae8769816a882480487deca4bf3 THRET-D(deps-dev): Bump @angular-eslint/eslint-plugin-template (#48)
- cc9fe4866b86e828ae0de630afdf5f5e9b18b075 THRET-D(deps-dev): Bump @angular-eslint/template-parser (#50)
- 457a75dc248aad8e2dde3b2d1f70aefc130d391e THRET-22: Pass server port as executable option (#49)
