### PR TITLE
THRET-R: Dependency update

### DIFF
--- a/thret-clothing-web-ui/package.json
+++ b/thret-clothing-web-ui/package.json
@@ -60,7 +60,7 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsdoc": "30.7.8",
     "eslint-plugin-prefer-arrow": "1.2.2",
-    "@angular-eslint/builder": "0.8.0-beta.1",
+    "@angular-eslint/builder": "0.8.0-beta.2",
     "@angular-eslint/eslint-plugin": "0.8.0-beta.2",
     "@angular-eslint/eslint-plugin-template": "0.8.0-beta.2",
     "@angular-eslint/schematics": "^0.8.0-beta.1",

--- a/thret-clothing-web-ui/package.json
+++ b/thret-clothing-web-ui/package.json
@@ -66,6 +66,6 @@
     "@angular-eslint/schematics": "^0.8.0-beta.1",
     "@angular-eslint/template-parser": "0.8.0-beta.2",
     "@typescript-eslint/eslint-plugin": "4.8.1",
-    "@typescript-eslint/parser": "4.8.1"
+    "@typescript-eslint/parser": "4.8.2"
   }
 }

--- a/thret-clothing-web-ui/package.json
+++ b/thret-clothing-web-ui/package.json
@@ -44,7 +44,7 @@
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/luxon": "^1.25.0",
-    "@types/node": "^12.11.1",
+    "@types/node": "^14.14.9",
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",

--- a/thret-clothing-web-ui/package.json
+++ b/thret-clothing-web-ui/package.json
@@ -65,7 +65,7 @@
     "@angular-eslint/eslint-plugin-template": "0.8.0-beta.2",
     "@angular-eslint/schematics": "^0.8.0-beta.1",
     "@angular-eslint/template-parser": "0.8.0-beta.2",
-    "@typescript-eslint/eslint-plugin": "4.8.1",
+    "@typescript-eslint/eslint-plugin": "4.8.2",
     "@typescript-eslint/parser": "4.8.2"
   }
 }

--- a/thret-clothing-web-ui/pom.xml
+++ b/thret-clothing-web-ui/pom.xml
@@ -14,7 +14,7 @@
   <artifactId>thret-clothing-web-ui</artifactId>
 
   <properties>
-    <frontend.plugin.version>1.10.3</frontend.plugin.version>
+    <frontend.plugin.version>1.10.4</frontend.plugin.version>
     <frontend.node.version>14.15.1</frontend.node.version>
   </properties>
 


### PR DESCRIPTION
A small update to ensure our live tech stack is using more recent versions of our dependencies. Especially after the new ESLint change where some deps are still in beta.

### Changelog
- 374590ac52e90297f5afcce5ac387879fd32c4a1 THRET-D(deps-dev): Bump @typescript-eslint/eslint-plugin (#57)
- 515f7e6f6021f1dcf806eb9eb0e2cfd840aa11c1 THRET-D(deps): Bump frontend-maven-plugin from 1.10.3 to 1.10.4 (#58)
- 1e8b926b10f79e84fed5133d7a38601fb18d61e2 THRET-D(deps-dev): Bump @angular-eslint/builder (#56)
- 18a50ce762219c4429ddf3fbfccd19576f5bacbd THRET-D(deps-dev): Bump @types/node in /thret-clothing-web-ui (#55)
- d64df97b0b213494e7a4e24156c45609909c914e THRET-D(deps-dev): Bump @typescript-eslint/parser (#54)
