### PR TITLE
THRET-26: Migrate from Heroku to Google Cloud Platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:14-slim as buildContainer
+WORKDIR /app
+COPY ./package.json ./package-lock.json /app/
+RUN npm install
+COPY . /app
+RUN npm run build:ssr
+
+FROM node:14-slim
+WORKDIR /app
+COPY --from=buildContainer /app/package.json /app
+COPY --from=buildContainer /app/dist /app/dist
+EXPOSE 8080
+CMD ["npm", "run", "serve:ssr"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: npm run serve:ssr

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start:ssr": "ng run thret:serve-ssr",
     "build": "ng build",
     "build:prod": "ng build --prod",
-    "build:ssr": "ng build --prod && ng run thret:server:production",
+    "build:ssr": "ngcc --tsconfig='./config/ts/tsconfig.server.json' && ng build --prod && ng run thret:server:production",
     "test": "ng test",
     "test:watch": "ng test --watch",
     "test:headless": "ng test -c=headless",
@@ -21,8 +21,7 @@
     "lint": "ng lint",
     "prerender": "ng run thret:prerender",
     "serve:ssr": "node dist/thret/server/main.js",
-    "postinstall": "ngcc --tsconfig='./config/ts/tsconfig.app.json'",
-    "heroku-postbuild": "ngcc --tsconfig='./config/ts/tsconfig.server.json' && npm run build:ssr"
+    "postinstall": "ngcc --tsconfig='./config/ts/tsconfig.app.json'"
   },
   "dependencies": {
     "@angular/animations": "11.0.0",


### PR DESCRIPTION
As decided in the determination from research done under the related business task, we'll be moving our services from Heroku to the Google Cloud Platform.

### Acceptance Criteria
- Add Google Cloud `Dockerfile`
- Remove Heroku `Procfile`