### PR TITLE
THRET-26: Add missing ng-universal files & fix Docker locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:14-slim as buildContainer
-WORKDIR /app
-COPY ./package.json ./package-lock.json /app/
+WORKDIR /usr/src/app
+COPY package*.json ./
 RUN npm install
-COPY . /app
+COPY . ./
 RUN npm run build:ssr
 
 FROM node:14-slim
-WORKDIR /app
-COPY --from=buildContainer /app/package.json /app
-COPY --from=buildContainer /app/dist /app/dist
+WORKDIR /usr/src/app
+COPY --from=buildContainer /usr/src/app/package*.json ./
+COPY --from=buildContainer /usr/src/app/dist ./
 EXPOSE 8080
 CMD ["npm", "run", "serve:ssr"]

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { ServerModule } from '@angular/platform-server';
+import { AppModule } from './app.module';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [
+    AppModule,
+    ServerModule,
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppServerModule {
+}

--- a/src/main.server.ts
+++ b/src/main.server.ts
@@ -1,0 +1,9 @@
+import { enableProdMode } from '@angular/core';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
+
+export { AppServerModule } from './app/app.server.module';
+export { renderModule, renderModuleFactory } from '@angular/platform-server';


### PR DESCRIPTION
Add missing angular universal files that were removed by stash which occurred before rebasing on old PR and fix the relative locations within `Dockerfile`.

### Acceptance Criteria
- [x] Build passes on GCP