### PR TITLE
THRET-R: Amend relative location issue in `main.server.js`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM node:14-slim as buildContainer
-WORKDIR /usr/src/app
-COPY package*.json ./
+WORKDIR /app
+COPY package*.json /app
 RUN npm install
-COPY . ./
+COPY . /app
 RUN npm run build:ssr
 
 FROM node:14-slim
-WORKDIR /usr/src/app
-COPY --from=buildContainer /usr/src/app/package*.json ./
-COPY --from=buildContainer /usr/src/app/dist ./
+WORKDIR /app
+COPY --from=buildContainer /app/package*.json /app
+COPY --from=buildContainer /app/dist /app/dist
+
 EXPOSE 8080
+
+ENV NODE_ENV production
 CMD ["npm", "run", "serve:ssr"]


### PR DESCRIPTION
Amend issue with relative locations inside of the `Dockerfile` that was causing the push and run stage to fail on GCP due to module lookup issues within `main.server.js`.

### Changelog
- b3a29a5 THRET-26: Amend relative location issue in `main.server.js`