### PR TITLE
THRET-26: Ensure Dockerfile is correctly formatted for directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:14-slim as buildContainer
 WORKDIR /app
-COPY package*.json /app
+COPY package*.json /app/
 RUN npm install
 COPY . /app
 RUN npm run build:ssr
 
 FROM node:14-slim
 WORKDIR /app
-COPY --from=buildContainer /app/package*.json /app
-COPY --from=buildContainer /app/dist /app/dist
+COPY --from=buildContainer /app/package*.json /app/
+COPY --from=buildContainer /app/dist/ /app/dist/
 
 EXPOSE 8080
 


### PR DESCRIPTION
Fix the following issue:

```bash
Step #0 - "Build": Step 9/13 : COPY --from=buildContainer /app/package*.json /app
Step #0 - "Build": When using COPY with more than one source file, the destination must be a directory and end with a /
```

### Acceptance Criteria
- [x] GCP build stage passes again