### PR TITLE
THRET-R: Ensure Dockerfile is correctly formatted for directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:14-slim as buildContainer
 WORKDIR /app
-COPY package*.json /app
+COPY package*.json /app/
 RUN npm install
 COPY . /app
 RUN npm run build:ssr
 
 FROM node:14-slim
 WORKDIR /app
-COPY --from=buildContainer /app/package*.json /app
-COPY --from=buildContainer /app/dist /app/dist
+COPY --from=buildContainer /app/package*.json /app/
+COPY --from=buildContainer /app/dist/ /app/dist/
 
 EXPOSE 8080
 


### PR DESCRIPTION
Fix issue observed where the `COPY` command fails on the build stage in GCP, due to incorrectly formatted directory location.

### Changelog
- 72e3875 THRET-26: Ensure Dockerfile is correctly formatted for directories