### PR TITLE
THRET-31: Remove falsy check and improve IP logging output

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -31,13 +31,7 @@ export function app(): express.Express {
    * Catch all other requests and route to the Universal engine
    */
   server.get('*', (req, res) => {
-
-    const cloudflareHeader = req.header('CF-Connecting-IP');
-
-    if (cloudflareHeader) {
-      console.log(`${req.method} request for: ${req.originalUrl}, by resolved IP Address: ${cloudflareHeader}`);
-    }
-
+    console.log(`${req.method} request for: ${req.originalUrl}, by resolved IP Address: ${req.get('CF-Connecting-IP') || 'N/A'}`);
     res.render(indexHtml, {req, providers: [{provide: APP_BASE_HREF, useValue: req.baseUrl}]});
   });
 


### PR DESCRIPTION
Remove falsy check and improve IP logging output as. current implementation is not showing in GCP logs.

### Acceptance Criteria
- [x] Always log end-user IP when possible.