### PR TITLE
THRET-32: Enable IP logging as middleware

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -20,6 +20,11 @@ export function app(): express.Express {
   server.set('view engine', 'html');
   server.set('views', distFolder);
 
+  server.use((req, res, next) => {
+    console.log(`${req.method} request for: ${req.originalUrl}, by resolved IP Address: ${req.get('CF-Connecting-IP') || 'N/A'}`);
+    next();
+  });
+
   /**
    * Forward all requests for assets to the static dist folder
    */
@@ -31,7 +36,6 @@ export function app(): express.Express {
    * Catch all other requests and route to the Universal engine
    */
   server.get('*', (req, res) => {
-    console.log(`${req.method} request for: ${req.originalUrl}, by resolved IP Address: ${req.get('CF-Connecting-IP') || 'N/A'}`);
     res.render(indexHtml, {req, providers: [{provide: APP_BASE_HREF, useValue: req.baseUrl}]});
   });
 


### PR DESCRIPTION
Enable IP logging within middleware as bots are circumventing request logs by deliberately appending `.php` in their request, which to our server is treated as an asset and forwarded away from the log.

### Acceptance Criteria
- [x] Log all requests, including asset requests and the end-user IP