### PR TITLE
THRET-R: Expose end-user IP via middleware

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -31,13 +31,7 @@ export function app(): express.Express {
    * Catch all other requests and route to the Universal engine
    */
   server.get('*', (req, res) => {
-
-    const cloudflareHeader = req.header('CF-Connecting-IP');
-
-    if (cloudflareHeader) {
-      console.log(`${req.method} request for: ${req.originalUrl}, by resolved IP Address: ${cloudflareHeader}`);
-    }
-
+    console.log(`${req.method} request for: ${req.originalUrl}, by resolved IP Address: ${req.get('CF-Connecting-IP') || 'N/A'}`);
     res.render(indexHtml, {req, providers: [{provide: APP_BASE_HREF, useValue: req.baseUrl}]});
   });
 

--- a/server.ts
+++ b/server.ts
@@ -20,6 +20,11 @@ export function app(): express.Express {
   server.set('view engine', 'html');
   server.set('views', distFolder);
 
+  server.use((req, res, next) => {
+    console.log(`${req.method} request for: ${req.originalUrl}, by resolved IP Address: ${req.get('CF-Connecting-IP') || 'N/A'}`);
+    next();
+  });
+
   /**
    * Forward all requests for assets to the static dist folder
    */
@@ -31,7 +36,6 @@ export function app(): express.Express {
    * Catch all other requests and route to the Universal engine
    */
   server.get('*', (req, res) => {
-    console.log(`${req.method} request for: ${req.originalUrl}, by resolved IP Address: ${req.get('CF-Connecting-IP') || 'N/A'}`);
     res.render(indexHtml, {req, providers: [{provide: APP_BASE_HREF, useValue: req.baseUrl}]});
   });
 


### PR DESCRIPTION
Since bots are directly pinging URLs ending with `.php` and `.xml`, exposing the requestor IP as a middleware on all requests will enable us to snoop on every request inbound to our UI.

### Changelog
- ad4567ed3ad45f2a48363c97d1dc581e4b2b813b THRET-32: Enable IP logging as middleware
- 4b3c79ceeb2b6ea4dc57c6dec2ab5cb2deff56db THRET-31: Remove falsy check and improve IP logging output
