### PR TITLE
THRET-38: Add canonical tag to UI project for redirects

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -15,6 +15,8 @@
 
   <title>Thret Clothing Co.</title>
 
+  <link rel="canonical" href="https://thretclothing.com">
+
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="apple-touch-icon" sizes="180x180" href="assets/images/icons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="assets/images/icons/favicon-32x32.png">


### PR DESCRIPTION
Google appears to be indexing the short domain for Thret, even when specifying the correct redirect response code. To prevent this from happening, we'll add a canonical relationship tag to the website, so when scraped, Google will have no choice but to index our full URL.

### Acceptance Criteria
- [x] Canonical relationship established on the UI project